### PR TITLE
Service refactor

### DIFF
--- a/DependencyInjection/InnobyteTokenExtension.php
+++ b/DependencyInjection/InnobyteTokenExtension.php
@@ -4,6 +4,7 @@ namespace Innobyte\TokenBundle\DependencyInjection;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\DependencyInjection\Loader;
 
@@ -27,10 +28,10 @@ class InnobyteTokenExtension extends Extension
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
 
-        $container->setParameter(
-            'innobyte_token.entity_manager_service_name',
-            sprintf('doctrine.orm.%s_entity_manager', $config['entity_manager'])
-        );
+        $container
+            ->getDefinition('innobyte_token.token')
+            ->replaceArgument(0, new Reference(sprintf('doctrine.orm.%s_entity_manager', $config['entity_manager'])))
+        ;
 
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.yml');

--- a/DependencyInjection/InnobyteTokenExtension.php
+++ b/DependencyInjection/InnobyteTokenExtension.php
@@ -28,12 +28,12 @@ class InnobyteTokenExtension extends Extension
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
 
+        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
+        $loader->load('services.yml');
+
         $container
             ->getDefinition('innobyte_token.token')
             ->replaceArgument(0, new Reference(sprintf('doctrine.orm.%s_entity_manager', $config['entity_manager'])))
         ;
-
-        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
-        $loader->load('services.yml');
     }
 }

--- a/Exception/TokenConsumedException.php
+++ b/Exception/TokenConsumedException.php
@@ -12,6 +12,6 @@ namespace Innobyte\TokenBundle\Exception;
  *
  * @author Sorin Dumitrescu <sorin.dumitrescu@innobyte.com>
  */
-class TokenConsumedException extends \LogicException
+class TokenConsumedException extends TokenException
 {
 }

--- a/Exception/TokenException.php
+++ b/Exception/TokenException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Innobyte\TokenBundle\Exception;
+
+/**
+ * Class TokenException
+ * Generic Token exception.
+ *
+ * @package Innobyte\TokenBundle\Exception
+ */
+class TokenException extends \LogicException
+{
+}

--- a/Exception/TokenExpiredException.php
+++ b/Exception/TokenExpiredException.php
@@ -12,6 +12,6 @@ namespace Innobyte\TokenBundle\Exception;
  *
  * @author Sorin Dumitrescu <sorin.dumitrescu@innobyte.com>
  */
-class TokenExpiredException extends \LogicException
+class TokenExpiredException extends TokenException
 {
 }

--- a/Exception/TokenInactiveException.php
+++ b/Exception/TokenInactiveException.php
@@ -12,6 +12,6 @@ namespace Innobyte\TokenBundle\Exception;
  *
  * @author Sorin Dumitrescu <sorin.dumitrescu@innobyte.com>
  */
-class TokenInactiveException extends \LogicException
+class TokenInactiveException extends TokenException
 {
 }

--- a/Exception/TokenNotFoundException.php
+++ b/Exception/TokenNotFoundException.php
@@ -12,6 +12,6 @@ namespace Innobyte\TokenBundle\Exception;
  *
  * @author Sorin Dumitrescu <sorin.dumitrescu@innobyte.com>
  */
-class TokenNotFoundException extends \LogicException
+class TokenNotFoundException extends TokenException
 {
 }

--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ Then, run ```app/console doctrine:schema:update --em=default --force``` to run t
         echo 'handle over-used token here';
     } catch (\Innobyte\TokenBundle\Exception\TokenExpiredException $e) {
         echo 'handle expired token here';
+    } catch (\Innobyte\TokenBundle\Exception\TokenException $e) {
+        // or, alternately, you can catch all token-related exceptions
+        echo 'handle all token-related exceptions';
     }
 
     echo 'Token is valid. Token is valid. Perform logic here.';

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -5,8 +5,8 @@ services:
     innobyte_token.token:
         class: %innobyte_token.token.class%
         arguments:
-            - @service_container                           # used only for getting the right Entity Manager
-            - %innobyte_token.entity_manager_service_name%
+            - ~ # will be replaced with the entity manager set in config
+            - @security.secure_random
         lazy: true
 
     # shorthand name

--- a/Service/TokenService.php
+++ b/Service/TokenService.php
@@ -44,6 +44,7 @@ class TokenService
     {
         $this->em = $entityManager;
         $this->repository = $this->em->getRepository(self::ENTITY_NAME);
+        $this->secureRandom = $secureRandom;
     }
 
     /**

--- a/Service/TokenService.php
+++ b/Service/TokenService.php
@@ -2,14 +2,15 @@
 
 namespace Innobyte\TokenBundle\Service;
 
+use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\UnitOfWork;
 use Innobyte\TokenBundle\Exception\TokenConsumedException;
 use Innobyte\TokenBundle\Exception\TokenExpiredException;
 use Innobyte\TokenBundle\Exception\TokenInactiveException;
 use Innobyte\TokenBundle\Exception\TokenNotFoundException;
-use Symfony\Component\DependencyInjection\Container;
 use Doctrine\ORM\EntityManager;
 use Innobyte\TokenBundle\Entity\Token;
+use Symfony\Component\Security\Core\Util\SecureRandomInterface;
 
 /**
  * Class TokenService
@@ -21,30 +22,28 @@ use Innobyte\TokenBundle\Entity\Token;
  */
 class TokenService
 {
+    const ENTITY_NAME = 'InnobyteTokenBundle:Token';
+
     /**
      * @var EntityManager
      */
     protected $em;
 
+    /** @var EntityRepository */
+    protected $repository;
+
+    /** @var SecureRandomInterface */
+    protected $secureRandom;
+
     /**
      * Initialize
      *
-     * @param Container $container DI Container - used only for getting the right Entity Manager
-     * @param string    $emName    Name of the Entity Manager to fetch
+     * @param EntityManager $entityManager
      */
-    public function __construct(Container $container, $emName)
+    public function __construct(EntityManager $entityManager, SecureRandomInterface $secureRandom)
     {
-        $this->em = $container->get($emName);
-    }
-
-    /**
-     * Get the entity manager
-     *
-     * @return EntityManager
-     */
-    protected function getEm()
-    {
-        return $this->em;
+        $this->em = $entityManager;
+        $this->repository = $this->em->getRepository(self::ENTITY_NAME);
     }
 
     /**
@@ -61,7 +60,7 @@ class TokenService
      */
     public function generate($scope, $ownerType, $ownerId, $usesMax = 1, \DateTime $expiresAt = null, array $data = null)
     {
-        $hash = md5(uniqid() . $scope . $ownerType . $ownerId);
+        $hash = md5($this->secureRandom->nextBytes(32) . $scope . $ownerType . $ownerId);
 
         $token = new Token();
         $token->setHash($hash)
@@ -78,8 +77,8 @@ class TokenService
             $token->setExpiresAt($expiresAt);
         }
 
-        $this->getEm()->persist($token);
-        $this->getEm()->flush($token);
+        $this->em->persist($token);
+        $this->em->flush($token);
 
         return $token;
     }
@@ -98,7 +97,7 @@ class TokenService
      */
     public function get($hash, $scope, $ownerType, $ownerId)
     {
-        $token = $this->getEm()->getRepository('InnobyteTokenBundle:Token')->findOneBy(
+        $token = $this->repository->findOneBy(
             array(
                 'hash'      => $hash,
                 'scope'     => $scope,
@@ -183,7 +182,7 @@ class TokenService
      */
     public function consumeToken(Token $token)
     {
-        if ($this->getEm()->getUnitOfWork()->getEntityState($token) != UnitOfWork::STATE_MANAGED) {
+        if ($this->em->getUnitOfWork()->getEntityState($token) != UnitOfWork::STATE_MANAGED) {
             throw new \LogicException('The Token must be managed by Doctrine in order to be consumed.');
         }
 
@@ -191,7 +190,7 @@ class TokenService
             $token->getUsesCount() + 1
         );
 
-        $this->getEm()->flush($token);
+        $this->em->flush($token);
     }
 
     /**
@@ -226,12 +225,12 @@ class TokenService
      */
     public function invalidateToken(Token $token)
     {
-        if ($this->getEm()->getUnitOfWork()->getEntityState($token) != UnitOfWork::STATE_MANAGED) {
+        if ($this->em->getUnitOfWork()->getEntityState($token) != UnitOfWork::STATE_MANAGED) {
             throw new \LogicException('The Token must be managed by Doctrine in order to be consumed.');
         }
 
         $token->setActive(false);
 
-        $this->getEm()->flush($token);
+        $this->em->flush($token);
     }
 }


### PR DESCRIPTION
I have refactored the TokenService a bit.

First of all, you don't need the Container in order to get the EntityManager. You have semantic configuration which gives you the entity manager's name. In the Extension class you can replace TokenService's argument with the reference to the entity manager mentioned in config.

Also, Symfony's SecureRandom implementation is a far better option for proper random hashes.

I have also removed TokenService::getEm() as well... seemed like a useless extension point.

Thanks !
